### PR TITLE
Revert "Handle authentication error response."

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -76,9 +76,6 @@ class OIDCAuthentication(object):
         authn_resp = self.client.parse_response(AuthorizationResponse, info=query_string,
                                                 sformat='urlencoded')
 
-        if 'error' in authn_resp:
-            return self._return_to_view()
-
         if authn_resp['state'] != flask.session.pop('state'):
             raise ValueError('The \'state\' parameter does not match.')
 
@@ -108,17 +105,14 @@ class OIDCAuthentication(object):
         if userinfo:
             flask.session['userinfo'] = userinfo.to_dict()
 
-        return self._return_to_view()
+        destination = flask.session.pop('destination')
+        return redirect(destination)
 
     def _do_userinfo_request(self, state, userinfo_endpoint_method):
         if userinfo_endpoint_method is None:
             return None
 
         return self.client.do_user_info_request(method=userinfo_endpoint_method, state=state)
-
-    def _return_to_view(self):
-        destination = flask.session.pop('destination')
-        return redirect(destination)
 
     def _reauthentication_necessary(self, id_token):
         return not id_token

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -104,17 +104,6 @@ class TestOIDCAuthentication(object):
         assert not client_mock.construct_AuthorizationRequest.called
         assert callback_mock.called is True
 
-    def test_handle_authentication_error_response_by_redirect_to_view(self):
-        view_endpoint = '/view-endpoint'
-        authn = OIDCAuthentication(self.app, provider_configuration_info={'issuer': ISSUER},
-                                   client_registration_info={'client_id': 'foo'})
-        with self.app.test_request_context('/redirect_uri?error=invalid_request&error_description=test_error'):
-            flask.session['destination'] = view_endpoint
-            response = authn._handle_authentication_response()
-
-        assert response.status_code == 302
-        assert response.location == view_endpoint
-
     def test_logout(self):
         end_session_endpoint = 'https://provider.example.com/end_session'
         post_logout_uri = 'https://client.example.com/post_logout'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35
 
 [testenv]
 commands = py.test tests/


### PR DESCRIPTION
Reverts zamzterz/Flask-pyoidc#10

Shouldn't redirect back to view since that will end up in eternal redirect loop, with the view triggering the authentication again.