### PR TITLE
Store the signed ID Token in user session.

### DIFF
--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -1,4 +1,5 @@
 import base64
+import json
 
 import logging
 from oic.oic import Client, ProviderConfigurationResponse, RegistrationResponse, AuthorizationResponse, \
@@ -126,14 +127,16 @@ class PyoidcFacade(object):
                   data=request,
                   headers=auth_header) \
             .json()
+        logger.debug('received token response: %s', json.dumps(resp))
 
         if 'error' in resp:
             token_resp = TokenErrorResponse(**resp)
         else:
             token_resp = AccessTokenResponse(**resp)
             token_resp.verify(keyjar=self._client.keyjar)
+            if 'id_token' in resp:
+                token_resp['id_token_jwt'] = resp['id_token']
 
-        logger.debug('received token response: %s', token_resp.to_json())
         return token_resp
 
     def userinfo_request(self, access_token):

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,10 @@
+from jwkest.jwk import SYMKey
+from oic import rndstr
+from oic.oic import IdToken
+
+
+def signed_id_token(claims):
+    id_token = IdToken(**claims)
+    signing_key = SYMKey(alg='HS256', key=rndstr())
+    jws = id_token.to_jwt(key=[signing_key], algorithm=signing_key.alg)
+    return jws, signing_key


### PR DESCRIPTION
Previously the real signature was removed, and a plain (unsigned) JWT
containing the same claims as the original ID Token was stored in the
session. This prevented it from being properly validated when forwarded
as 'id_token_hint' in logout requests.