### PR TITLE
Allow the user session lifetime to be configured via Flask.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,10 @@ The application using this extension **MUST** set the following
 
 You may also configure the way the user sessions created by this extension are handled:
 
-* `OIDC_SESSION_PERMANENT`: If set to `True` (which is the default) the user session will live until the ID Token
-  expiration time. If set to `False` the session will be deleted when the user closes the browser.
+* `OIDC_SESSION_PERMANENT`: If set to `True` (which is the default) the user session will be kept until the configured
+  session lifetime (see below). If set to `False` the session will be deleted when the user closes the browser.
+* `PERMANENT_SESSION_LIFETIME`: Control how long a user session is valid, see
+  [Flask documentation](http://flask.pocoo.org/docs/1.0/config/#PERMANENT_SESSION_LIFETIME) for more information.
 
 ### Session refresh
 

--- a/example/app.py
+++ b/example/app.py
@@ -1,3 +1,5 @@
+import datetime
+
 import flask
 import logging
 from flask import Flask, jsonify
@@ -10,6 +12,7 @@ app = Flask(__name__)
 # See http://flask.pocoo.org/docs/0.12/config/
 app.config.update({'SERVER_NAME': 'localhost:5000',
                    'SECRET_KEY': 'dev_key',  # make sure to change this!!
+                   'PERMANENT_SESSION_LIFETIME': datetime.timedelta(days=7).total_seconds(),
                    'PREFERRED_URL_SCHEME': 'http',
                    'DEBUG': True})
 

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -127,10 +127,6 @@ class OIDCAuthentication(object):
                 raise ValueError('The \'nonce\' parameter does not match.')
 
             id_token_claims = id_token.to_dict()
-            # set the session as requested by the OP if we have no default
-            if current_app.config.get('OIDC_SESSION_PERMANENT', True):
-                flask.session.permanent = True
-                flask.session.permanent_session_lifetime = id_token['exp'] - time.time()
 
         # do userinfo request
         userinfo = client.userinfo_request(access_token)
@@ -140,6 +136,9 @@ class OIDCAuthentication(object):
 
         if id_token_claims and userinfo_claims and userinfo_claims['sub'] != id_token_claims['sub']:
             raise ValueError('The \'sub\' of userinfo does not match \'sub\' of ID Token.')
+
+        if current_app.config.get('OIDC_SESSION_PERMANENT', True):
+            flask.session.permanent = True
 
         UserSession(flask.session).update(access_token,
                                           id_token_claims,


### PR DESCRIPTION
Don't use the ID Token expiration time since that is unrelated to the
user sessions kept by the client.