### PR TITLE
Djbeadle https redirect uri

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -62,7 +62,7 @@ class OIDCAuthentication(object):
         with app.app_context():
             url_scheme = 'https' if current_app.config.get('REDIRECT_URI_FORCE_HTTPS', False) else 'http'
             self.clients = {
-                name: PyoidcFacade(configuration, url_for(self.REDIRECT_URI_ENDPOINT, _scheme=url_scheme))
+                name: PyoidcFacade(configuration, url_for(self.REDIRECT_URI_ENDPOINT, _external=True, _scheme=url_scheme))
                 for (name, configuration) in self._provider_configurations.items()
             }
 

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -60,8 +60,9 @@ class OIDCAuthentication(object):
 
         # dynamically add the Flask redirect uri to the client info
         with app.app_context():
+            url_scheme = 'https' if current_app.config.get('REDIRECT_URI_FORCE_HTTPS', False) else 'http'
             self.clients = {
-                name: PyoidcFacade(configuration, url_for(self.REDIRECT_URI_ENDPOINT))
+                name: PyoidcFacade(configuration, url_for(self.REDIRECT_URI_ENDPOINT, _scheme=url_scheme))
                 for (name, configuration) in self._provider_configurations.items()
             }
 


### PR DESCRIPTION
I've been working with Azure App service which does not allow **_any_** http callbacks except for localhost, so the ProxyFix solution mentioned in #44 doesn't apply.

This change sets the parameter "_scheme" on url_for() in OIDCAuthentication.init_app() based on the config value "REDIRECT_URI_FORCE_HTTPS". If the config value is set to True it the redirect uri will be configured to use https. 

If no value is set or REDIRECT_URI_FORCE_HTTPS equals false the redirect uri equals http and no behavior is changed.

I'm not sure where to document this setting, but if accepted please let me know and I will write it up!