### PR TITLE
Allow 'post_logout_redirect_uri' to be configured in client metadata.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ def logout():
     return 'You\'ve been successfully logged out!'
 ```
 
+If the logout view is mounted under a custom endpoint
+([Flask uses the name of the view function as default](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route)) or in an app using Blueprints, you
+must specify the full URL in the Flask-pyoidc configuration using `post_logout_redirect_uris`:
+```python
+ClientMetadata(..., post_logout_redirect_uris=['https://example.com/post_logout']) # if using static client registration
+ClientRegistrationInfo(..., post_logout_redirect_uris=['https://example.com/post_logout']) # if using dynamic client registration 
+```
+
 This extension also supports [RP-Initiated Logout](http://openid.net/specs/openid-connect-session-1_0.html#RPLogout),
 if the provider allows it. Make sure the `end_session_endpoint` is defined in the provider metadata to enable notifying
 the provider when the user logs out. 

--- a/README.md
+++ b/README.md
@@ -169,8 +169,8 @@ def logout():
     return 'You\'ve been successfully logged out!'
 ```
 
-If the logout view is mounted under a custom endpoint
-([Flask uses the name of the view function as default](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route)) or in an app using Blueprints, you
+If the logout view is mounted under a custom endpoint (other than the default, which is 
+[the name of the view function](http://flask.pocoo.org/docs/1.0/api/#flask.Flask.route)), or if using Blueprints, you
 must specify the full URL in the Flask-pyoidc configuration using `post_logout_redirect_uris`:
 ```python
 ClientMetadata(..., post_logout_redirect_uris=['https://example.com/post_logout']) # if using static client registration

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -171,6 +171,10 @@ class PyoidcFacade(object):
         provider_metadata = self._provider_configuration.ensure_provider_metadata()
         return provider_metadata.get('end_session_endpoint')
 
+    @property
+    def post_logout_redirect_uris(self):
+        return self._client.registration_response.get('post_logout_redirect_uris')
+
     def _parse_response(self, response_params, success_response_cls, error_response_cls):
         if 'error' in response_params:
             response = error_response_cls(**response_params)


### PR DESCRIPTION
Fix #48.