### PR TITLE
Add ability to configure redirect uri (fixes #51)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ config = ProviderConfiguration([provider configuration], client_metadata=client_
 
 **Note: The redirect URIs registered with the provider MUST include `<application_url>/redirect_uri`,
 where `<application_url>` is the URL of the Flask application.**
+To configure this extension to use a different endpoint, set the
+[`OIDC_REDIRECT_ENDPOINT` configuration parameter](#flask-configuration).
 
 #### Dynamic client registration
 
@@ -91,6 +93,8 @@ You may also configure the way the user sessions created by this extension are h
 
 * `OIDC_SESSION_PERMANENT`: If set to `True` (which is the default) the user session will be kept until the configured
   session lifetime (see below). If set to `False` the session will be deleted when the user closes the browser.
+* `OIDC_REDIRECT_ENDPOINT`: Set the endpoint used as redirect_uri to receive authentication responses. Defaults to
+  `redirect_uri`, meaning the URL `<application_url>/redirect_uri` needs to be registered with the provider(s).
 * `PERMANENT_SESSION_LIFETIME`: Control how long a user session is valid, see
   [Flask documentation](http://flask.pocoo.org/docs/1.0/config/#PERMANENT_SESSION_LIFETIME) for more information.
 

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -54,17 +54,13 @@ class OIDCAuthentication(object):
         self.clients = None
         self._logout_view = None
         self._error_view = None
-        self._redirect_uri_endpoint = 'redirect_uri'
+        self._redirect_uri_endpoint = None
 
         if app:
             self.init_app(app)
 
     def init_app(self, app):
-        if 'OIDC_REDIRECT_ENDPOINT' in app.config:
-            redirect_endpoint = app.config.get('OIDC_REDIRECT_ENDPOINT')
-            if redirect_endpoint[0] == '/':
-                raise ValueError('The OIDC_REDIRECT_ENDPOINT should not start with a slash.')
-            self._redirect_uri_endpoint = redirect_endpoint
+        self._redirect_uri_endpoint = app.config.get('OIDC_REDIRECT_ENDPOINT', 'redirect_uri').lstrip('/')
 
         # setup redirect_uri as a flask route
         app.add_url_rule('/' + self._redirect_uri_endpoint,

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -167,7 +167,7 @@ class OIDCAuthentication(object):
             # if the current request was from the JS page handling fragment encoded responses we need to return
             # a URL for the error page to redirect to
             flask.session['error'] = error_response
-            return '/redirect_uri?error=1'
+            return '/' + self._redirect_uri_endpoint + '?error=1'
         return self._show_error_response(error_response)
 
     def _show_error_response(self, error_response):

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -470,13 +470,7 @@ class TestOIDCAuthentication(object):
         assert 'unknown' in str(exc_info.value)
 
     def test_should_use_custom_redirect_endpoint(self):
-        self.app.config['OIDC_REDIRECT_ENDPOINT'] = 'openid_connect_login'
+        self.app.config['OIDC_REDIRECT_ENDPOINT'] = '/openid_connect_login'
         authn = self.init_app()
         assert authn._redirect_uri_endpoint == 'openid_connect_login'
         assert authn.clients['test_provider']._redirect_uri == 'http://client.example.com/openid_connect_login'
-
-    def test_error_when_redirect_endpoint_has_slash(self):
-        self.app.config['OIDC_REDIRECT_ENDPOINT'] = '/openid_connect_login'
-
-        with pytest.raises(ValueError, match='The OIDC_REDIRECT_ENDPOINT should not start with a slash.'):
-            self.init_app()

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -468,3 +468,15 @@ class TestOIDCAuthentication(object):
         with pytest.raises(ValueError) as exc_info:
             self.init_app().oidc_auth('unknown')
         assert 'unknown' in str(exc_info.value)
+
+    def test_should_use_custom_redirect_endpoint(self):
+        self.app.config['OIDC_REDIRECT_ENDPOINT'] = 'openid_connect_login'
+        authn = self.init_app()
+        assert authn._redirect_uri_endpoint == 'openid_connect_login'
+        assert authn.clients['test_provider']._redirect_uri == 'http://client.example.com/openid_connect_login'
+
+    def test_error_when_redirect_endpoint_has_slash(self):
+        self.app.config['OIDC_REDIRECT_ENDPOINT'] = '/openid_connect_login'
+
+        with pytest.raises(ValueError, match='The OIDC_REDIRECT_ENDPOINT should not start with a slash.'):
+            self.init_app()


### PR DESCRIPTION
Presently this is missing support for the implicit flow:

https://github.com/zamzterz/Flask-pyoidc/blob/c1494d755af1d427bc214446699eb97f951eb09d/src/flask_pyoidc/files/parse_fragment.html#L5

https://github.com/zamzterz/Flask-pyoidc/blob/c1494d755af1d427bc214446699eb97f951eb09d/src/flask_pyoidc/flask_pyoidc.py#L164