### PR TITLE
Update oic dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ matrix:
       env: TOXENV=py36
     - python: 3.5
       env: TOXENV=py35
-    - python: 3.4
-      env: TOXENV=py34
 
 install:
   - pip install -U setuptools tox

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='samuel.gulliksson@gmail.com',
     description='Flask extension for OpenID Connect authentication.',
     install_requires=[
-        'oic==0.12',
+        'oic==1.1.2',
         'Flask',
         'requests'
     ],

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -2,8 +2,9 @@ import base64
 import json
 
 import logging
-from oic.oic import Client, ProviderConfigurationResponse, RegistrationResponse, AuthorizationResponse, \
+from oic.oic import Client, RegistrationResponse, AuthorizationResponse, \
     AccessTokenResponse, TokenErrorResponse, AuthorizationErrorResponse
+from oic.oic.message import ProviderConfigurationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
 
 logger = logging.getLogger(__name__)

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -250,7 +250,7 @@ class TestOIDCAuthentication(object):
         authn = self.init_app(provider_metadata_extras={'userinfo_endpoint': userinfo_endpoint})
         state = 'test_state'
         auth_response = AuthorizationResponse(
-            **{'state': state, 'access_token': access_token, 'id_token': id_token_jwt})
+            **{'state': state, 'access_token': access_token, 'token_type': 'Bearer', 'id_token': id_token_jwt})
         with self.app.test_request_context('/redirect_uri?{}'.format(auth_response.to_urlencoded())):
             UserSession(flask.session, self.PROVIDER_NAME)
             flask.session['destination'] = '/'
@@ -268,7 +268,7 @@ class TestOIDCAuthentication(object):
         state = 'test_state'
 
         authn = self.init_app()
-        auth_response = AuthorizationResponse(**{'state': state, 'access_token': access_token})
+        auth_response = AuthorizationResponse(**{'state': state, 'token_type': 'Bearer', 'access_token': access_token})
 
         with self.app.test_request_context('/redirect_uri',
                                            method='POST',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36,py37,py38
+envlist = py35,py36,py37,py38
 
 [testenv]
 commands = py.test tests/ example/


### PR DESCRIPTION
Update the oic dependency to the latest release.

Remove Python version 3.4 since it has reached end-of-life.
Please revise the added 'token_type' in the two tests.

Fix #64 