### PR TITLE
Fix silent session refresh

### DIFF
--- a/src/flask_pyoidc/user_session.py
+++ b/src/flask_pyoidc/user_session.py
@@ -36,6 +36,7 @@ class UserSession:
 
     def should_refresh(self, refresh_interval_seconds=None):
         return refresh_interval_seconds is not None and \
+               self._session_storage.get('last_session_refresh') is not None and \
                self._refresh_time(refresh_interval_seconds) < time.time()
 
     def _refresh_time(self, refresh_interval_seconds):

--- a/src/flask_pyoidc/user_session.py
+++ b/src/flask_pyoidc/user_session.py
@@ -11,7 +11,15 @@ class UserSession:
     Wraps comparison of times necessary for session handling.
     """
 
-    KEYS = ['access_token', 'current_provider', 'id_token', 'id_token_jwt', 'last_authenticated', 'last_session_refresh', 'userinfo']
+    KEYS = [
+        'access_token',
+        'current_provider',
+        'id_token',
+        'id_token_jwt',
+        'last_authenticated',
+        'last_session_refresh',
+        'userinfo'
+    ]
 
     def __init__(self, session_storage, provider_name=None):
         self._session_storage = session_storage

--- a/src/flask_pyoidc/user_session.py
+++ b/src/flask_pyoidc/user_session.py
@@ -11,7 +11,7 @@ class UserSession:
     Wraps comparison of times necessary for session handling.
     """
 
-    KEYS = ['access_token', 'current_provider', 'id_token', 'id_token_jwt', 'last_authenticated', 'userinfo']
+    KEYS = ['access_token', 'current_provider', 'id_token', 'id_token_jwt', 'last_authenticated', 'last_session_refresh', 'userinfo']
 
     def __init__(self, session_storage, provider_name=None):
         self._session_storage = session_storage
@@ -39,7 +39,7 @@ class UserSession:
                self._refresh_time(refresh_interval_seconds) < time.time()
 
     def _refresh_time(self, refresh_interval_seconds):
-        last = self._session_storage.get('last_authenticated', 0)
+        last = self._session_storage.get('last_session_refresh', 0)
         return last + refresh_interval_seconds
 
     def update(self, access_token=None, id_token=None, id_token_jwt=None, userinfo=None):
@@ -55,11 +55,13 @@ class UserSession:
             if value:
                 self._session_storage[session_key] = value
 
-        auth_time = int(time.time())
+        now = int(time.time())
+        auth_time = now
         if id_token:
             auth_time = id_token.get('auth_time', auth_time)
 
         self._session_storage['last_authenticated'] = auth_time
+        self._session_storage['last_session_refresh'] = now
         set_if_defined('access_token', access_token)
         set_if_defined('id_token', id_token)
         set_if_defined('id_token_jwt', id_token_jwt)

--- a/tests/test_user_session.py
+++ b/tests/test_user_session.py
@@ -54,8 +54,8 @@ class TestUserSession(object):
         session_storage = {'last_session_refresh': time.time() - (refresh_interval + 1)}
         assert self.initialised_session(session_storage).should_refresh(refresh_interval) is True
 
-    def test_should_refresh_if_supported_and_not_previously_authenticated(self):
-        assert self.initialised_session({}).should_refresh(10) is True
+    def test_should_not_refresh_if_not_previously_authenticated(self):
+        assert self.initialised_session({}).should_refresh(10) is False
 
     @pytest.mark.parametrize('data', [
         {'access_token': 'test_access_token'},

--- a/tests/test_user_session.py
+++ b/tests/test_user_session.py
@@ -71,7 +71,11 @@ class TestUserSession(object):
 
         self.initialised_session(storage).update(**data)
 
-        expected_session_data = {'last_authenticated': auth_time, 'last_session_refresh': auth_time, 'current_provider': self.PROVIDER_NAME}
+        expected_session_data = {
+            'last_authenticated': auth_time,
+            'last_session_refresh': auth_time,
+            'current_provider': self.PROVIDER_NAME
+        }
         expected_session_data.update(**data)
         assert storage == expected_session_data
 

--- a/tests/test_user_session.py
+++ b/tests/test_user_session.py
@@ -45,13 +45,13 @@ class TestUserSession(object):
 
     def test_should_not_refresh_if_authenticated_within_refresh_interval(self):
         refresh_interval = 10
-        session = self.initialised_session({'last_authenticated': time.time() + (refresh_interval - 1)})
+        session = self.initialised_session({'last_session_refresh': time.time() + (refresh_interval - 1)})
         assert session.should_refresh(refresh_interval) is False
 
     def test_should_refresh_if_supported_and_necessary(self):
         refresh_interval = 10
         # authenticated too far in the past
-        session_storage = {'last_authenticated': time.time() - (refresh_interval + 1)}
+        session_storage = {'last_session_refresh': time.time() - (refresh_interval + 1)}
         assert self.initialised_session(session_storage).should_refresh(refresh_interval) is True
 
     def test_should_refresh_if_supported_and_not_previously_authenticated(self):
@@ -71,7 +71,7 @@ class TestUserSession(object):
 
         self.initialised_session(storage).update(**data)
 
-        expected_session_data = {'last_authenticated': auth_time, 'current_provider': self.PROVIDER_NAME}
+        expected_session_data = {'last_authenticated': auth_time, 'last_session_refresh': auth_time, 'current_provider': self.PROVIDER_NAME}
         expected_session_data.update(**data)
         assert storage == expected_session_data
 
@@ -80,6 +80,15 @@ class TestUserSession(object):
         session = self.initialised_session({})
         session.update(id_token={'auth_time': auth_time})
         assert session.last_authenticated == auth_time
+
+    @patch('time.time')
+    def test_update_should_update_last_session_refresh_timestamp(self, time_mock):
+        now_timestamp = 1234
+        time_mock.return_value = now_timestamp
+        data = {}
+        session = self.initialised_session(data)
+        session.update()
+        assert data['last_session_refresh'] == now_timestamp
 
     def test_trying_to_update_uninitialised_session_should_throw_exception(self):
         with pytest.raises(UninitialisedSession):


### PR DESCRIPTION
* Keep a separate timestamp for when the session was last updated. 
After "silent authentication" ('prompt=none') a newly obtained ID Token
will contain the original original authentication timestamp, meaning
session.last_authenticated won't change. Hence a separate timestamp
is needed to correctly detect when session refresh should be triggered.
* Don't trigger session refresh if user isn't authenticated. 
Session refresh (using 'prompt=none') will fail with an error if the
user isn't logged in.

Fixes #67.