### PR TITLE
documentation improvement

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,12 +25,16 @@ from flask_pyoidc.provider_configuration import ProviderConfiguration, ProviderM
 
 provider_metadata = ProviderMetadata(issuer='https://op.example.com',
                                      authorization_endpoint='https://op.example.com/auth',
-                                     jwks_uri='https://op.example.com/jwks')
+                                     jwks_uri='https://op.example.com/jwks',
+                                     userinfo_endpoint='https://op.example.com/userinfo')
 config = ProviderConfiguration(provider_metadata=provider_metadata, [client configuration])
 ```
 
 See the OpenID Connect specification for more information about the
 [provider metadata](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
+
+As mentioned in OpenID Connect specification, `userinfo_endpoint` is optional. If it's
+not provided, no userinfo request will be done and `flask_pyoidc.UserSession.userinfo` will be set to `None`.  
 
 #### Customizing authentication request parameters
 To customize the [authentication request parameters](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,11 @@
 Welcome to flask-pyoidc's documentation!
 ========================================
 
+In addition to this documentation, you may have a look on some 
+`example code`_
+
+.. _example code: https://github.com/zamzterz/Flask-pyoidc/tree/master/example
+
 .. toctree::
    :maxdepth: 2
    :caption: Contents:

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,11 +26,30 @@ def index():
                    userinfo=user_session.userinfo)
 ```
 
+You can also use a Flask application factory:
+
+```python
+config = ProviderConfiguration(...)
+auth = OIDCAuthentication({'default': config})
+
+def create_app():
+    app = Flask(__name__)
+    app.config.update(
+        OIDC_REDIRECT_URI = 'https://example.com/redirect_uri',
+        SECRET_KEY = ...
+    )
+    auth.init_app(app)
+    return app
+```
+
 After a successful login, this extension will place three things in the user session (if they are received from the
 provider):
 * [ID Token](http://openid.net/specs/openid-connect-core-1_0.html#IDToken)
 * [Access Token](http://openid.net/specs/openid-connect-core-1_0.html#TokenResponse)
 * [Userinfo Response](http://openid.net/specs/openid-connect-core-1_0.html#UserInfoResponse)
+
+In addition to this documentation, you may have a look on a 
+[code example](https://github.com/zamzterz/Flask-pyoidc/tree/master/example).
 
 ## Using multiple providers
 

--- a/src/flask_pyoidc/provider_configuration.py
+++ b/src/flask_pyoidc/provider_configuration.py
@@ -58,6 +58,17 @@ class OIDCData(collections.MutableMapping):
 
 class ProviderMetadata(OIDCData):
     def __init__(self, issuer=None, authorization_endpoint=None, jwks_uri=None, **kwargs):
+        """
+        Args:
+            issuer (str): OP Issuer Identifier.
+            authorization_endpoint (str): URL of the OP's Authorization Endpoint
+            jwks_uri (str): URL of the OP's JSON Web Key Set
+            kwargs (dict): key-value pairs corresponding to
+                `OpenID Provider Metadata`_
+
+        .. _OpenID Provider Metadata:
+            https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata
+        """
         super(ProviderMetadata, self).__init__(issuer=issuer, authorization_endpoint=authorization_endpoint, jwks_uri=jwks_uri, **kwargs)
 
 
@@ -67,6 +78,13 @@ class ClientRegistrationInfo(OIDCData):
 
 class ClientMetadata(OIDCData):
     def __init__(self, client_id=None, client_secret=None, **kwargs):
+        """
+        Args:
+            client_id (str): client identifier representing the client
+            client_secret (str): client secret to authenticate the client with
+                the OP
+            kwargs (dict): key-value pairs
+        """
         super(ClientMetadata, self).__init__(client_id=client_id, client_secret=client_secret, **kwargs)
 
 


### PR DESCRIPTION
Related to previously issue opened #102 

- mention code examples in documentation
- mention `userinfo_endpoint` key on `ProviderMetadata`
- mention `OIDCAuthentication.init_app()`
- add docstring on `ProviderMetadata` and `ClientMetadata`