### PR TITLE
Test fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       env: TOXENV=py36
 
 install:
-  - pip install -U setuptools tox pip
+  - pip install -U setuptools tox pip virtualenv
   - pip install -e .
   - pip install pytest-cov codecov -r tests/requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
       env: TOXENV=py35
 
 install:
-  - pip install -U setuptools tox
+  - pip install -U setuptools tox pip
   - pip install -e .
   - pip install pytest-cov codecov -r tests/requirements.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ matrix:
       env: TOXENV=py37
     - python: 3.6
       env: TOXENV=py36
-    - python: 3.5
-      env: TOXENV=py35
 
 install:
   - pip install -U setuptools tox pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 
 matrix:
   include:
+    - python: 3.9
+      env: TOXENV=py39
     - python: 3.8
       env: TOXENV=py38
     - python: 3.7

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -403,7 +403,7 @@ class TestOIDCAuthentication(object):
         cookies = SimpleCookie()
         cookies.load(resp.headers['Set-Cookie'])
         session_cookie_expiration = cookies[self.app.config['SESSION_COOKIE_NAME']]['expires']
-        parsed_expiration = datetime.strptime(session_cookie_expiration, '%a, %d-%b-%Y %H:%M:%S GMT')
+        parsed_expiration = datetime.strptime(session_cookie_expiration, '%a, %d %b %Y %H:%M:%S GMT')
         cookie_lifetime = (parsed_expiration - datetime.utcnow()).total_seconds()
         assert cookie_lifetime == pytest.approx(session_lifetime, abs=1)
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38
+envlist = py36,py37,py38,py39
 
 [testenv]
 commands = py.test tests/ example/

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38
+envlist = py36,py37,py38
 
 [testenv]
 commands = py.test tests/ example/


### PR DESCRIPTION
Tests were failing to install 'cryptography' dependency on Travis and a small change in date format was introduced in Flask.

This also enables running the tests for Python 3.9 to ensure compatibility, while dropping testing agains Python 3.5 (which has reached EOL).

_Closes #106_