### PR TITLE
added token introspection and client credentials flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage.xml
 docs/_build
 docs/_static
 docs/_templates
+venv

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -368,7 +368,7 @@ class OIDCAuthentication:
         return access_token
 
     def introspect_token(self, request, client, scopes: list = None) -> Union[
-            TokenIntrospectionResponse, False]:
+            TokenIntrospectionResponse, bool]:
         '''RFC 7662: Token Introspection
         The Token Introspection extension defines a mechanism for resource
         servers to obtain information about access tokens. With this spec,

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -65,8 +65,8 @@ class OIDCAuthentication:
         # the request. It is available until current request only and is
         # destroyed between the request. The value is set by token_auth
         # decorator.
-        self.current_identity = LocalProxy(lambda: getattr(_app_ctx_stack.top,
-                                                           'current_identity',
+        self.current_token_identity = LocalProxy(lambda: getattr(_app_ctx_stack.top,
+                                                           'current_token_identity',
                                                            None))
         self._redirect_uri_config = redirect_uri_config
 
@@ -465,7 +465,7 @@ class OIDCAuthentication:
                     logger.info('user has valid access token')
                     # Store token introspection info within the application
                     # context.
-                    _app_ctx_stack.top.current_identity = token_introspection_result.to_dict()
+                    _app_ctx_stack.top.current_token_identity = token_introspection_result.to_dict()
                     return view_func(*args, **kwargs)
                 # Forbid access if the access token is invalid.
                 flask.abort(403)

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -61,13 +61,12 @@ class OIDCAuthentication:
         self.clients = None
         self._logout_view = None
         self._error_view = None
-        # current_identity proxy to obtain user info whose token was passed in
-        # the request. It is available until current request only and is
-        # destroyed between the request. The value is set by token_auth
+        # current_token_identity proxy to obtain user info whose token was
+        # passed in the request. It is available until current request only and
+        # is destroyed between the requests. The value is set by token_auth
         # decorator.
-        self.current_token_identity = LocalProxy(lambda: getattr(_app_ctx_stack.top,
-                                                           'current_token_identity',
-                                                           None))
+        self.current_token_identity = LocalProxy(lambda: getattr(
+            _app_ctx_stack.top, 'current_token_identity', None))
         self._redirect_uri_config = redirect_uri_config
 
         if app:

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -344,37 +344,37 @@ class OIDCAuthentication:
         return access_token
 
     def _check_authorization_header(self, request) -> bool:
-         '''Look for authorization in request header.
+        '''Look for authorization in request header.
 
-         Parameters
-         ----------
-         request : werkzeug.local.LocalProxy
-             flask request object.
+        Parameters
+        ----------
+        request : werkzeug.local.LocalProxy
+            flask request object.
 
-         Returns
-         -------
-         bool
-             True if the request header contains authorization else False.
-         '''
-         if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Bearer '):
-             return True
-         return False
+        Returns
+        -------
+        bool
+            True if the request header contains authorization else False.
+        '''
+        if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Bearer '):
+            return True
+        return False
 
     def _parse_access_token(self, request) -> str:
-         '''Parse access token from the authorization request header.
- 
-         Parameters
-         ----------
-         request : werkzeug.local.LocalProxy
-             flask request object.
- 
-         Returns
-         -------
-         accept_token : str
-             access token from the request header.
-         '''
-         _, access_token = request.headers['Authorization'].split(maxsplit=1)
-         return access_token
+        '''Parse access token from the authorization request header.
+
+        Parameters
+        ----------
+        request : werkzeug.local.LocalProxy
+            flask request object.
+
+        Returns
+        -------
+        accept_token : str
+            access token from the request header.
+        '''
+        _, access_token = request.headers['Authorization'].split(maxsplit=1)
+        return access_token
 
     def introspect_token(self, request, client, scopes: list = None) -> bool:
         '''RFC 7662: Token Introspection
@@ -435,8 +435,7 @@ class OIDCAuthentication:
             raise NotForMe('required audience is missing')
         # Check if scopes associated with the access_token are the ones
         # given by the user and not something else which is not permitted.
-        if not scopes and not set(scopes).issubset(
-                 set(result['scope'].split())):
-                logger.info('Token is valid but does not have required scopes')
-                raise NotForMe('Token does not have required scopes')
+        if scopes and not set(scopes).issubset(set(result['scope'])):
+            logger.info('Token is valid but does not have required scopes')
+            raise NotForMe('Token does not have required scopes')
         return True

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -270,7 +270,7 @@ class PyoidcFacade:
         """
         client_credentials_payload = {
             'grant_type': 'client_credentials'
-            }
+        }
         return self._token_request(request=client_credentials_payload)
 
     @property

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -295,25 +295,3 @@ class PyoidcFacade:
             response = success_response_cls(**response_params)
             response.verify(keyjar=self._client.keyjar)
         return response
-
-
-    @property
-    def session_refresh_interval_seconds(self):
-        return self._provider_configuration.session_refresh_interval_seconds
-
-    @property
-    def provider_end_session_endpoint(self):
-        provider_metadata = self._provider_configuration.ensure_provider_metadata()
-        return provider_metadata.get('end_session_endpoint')
-
-    @property
-    def post_logout_redirect_uris(self):
-        return self._client.registration_response.get('post_logout_redirect_uris')
-
-    def _parse_response(self, response_params, success_response_cls, error_response_cls):
-        if 'error' in response_params:
-            response = error_response_cls(**response_params)
-        else:
-            response = success_response_cls(**response_params)
-            response.verify(keyjar=self._client.keyjar)
-        return response

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -226,7 +226,7 @@ class PyoidcFacade:
         return userinfo_response
 
     def _token_introspection_request(self, access_token: str):
-        '''Make token introspection request
+        '''Make token introspection request.
 
         Parameters
         ----------
@@ -236,7 +236,7 @@ class PyoidcFacade:
         Returns
         -------
         oic.extension.message.TokenIntrospectionResponse
-            Response object contains result of the token introspection
+            Response object contains result of the token introspection.
         '''
         args = {
             'token': access_token,
@@ -263,12 +263,12 @@ class PyoidcFacade:
         On API call, token introspection will ensure that only valid token can
         be used to access your APIs.
         
-        How To Use?
-        -----------
-        >>>> auth = OIDCAuthentication({'default': provider_config},
+        How To Use
+        ----------
+        >>> auth = OIDCAuthentication({'default': provider_config},
                                        access_token_required=True)
-        >>>> auth.init_app(app)
-        >>>> auth.clients['default'].client_credentials_grant()
+        >>> auth.init_app(app)
+        >>> auth.clients['default'].client_credentials_grant()
         '''
         client_credentials_payload = {
             'grant_type': 'client_credentials'

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -51,7 +51,7 @@ class PyoidcFacade:
         """
         self._provider_configuration = provider_configuration
         self._client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
-        # Token Introspection is implmented in extension sub-package of the
+        # Token Introspection is implemented in extension sub-package of the
         # client in pyoidc
         self._client_extension = ClientExtension(client_authn_method=CLIENT_AUTHN_METHOD)
 
@@ -226,7 +226,7 @@ class PyoidcFacade:
         return userinfo_response
 
     def _token_introspection_request(self, access_token: str):
-        '''Make token introspection request.
+        """Make token introspection request.
 
         Parameters
         ----------
@@ -237,7 +237,7 @@ class PyoidcFacade:
         -------
         oic.extension.message.TokenIntrospectionResponse
             Response object contains result of the token introspection.
-        '''
+        """
         args = {
             'token': access_token,
             'client_id': self._client.client_id,
@@ -252,13 +252,11 @@ class PyoidcFacade:
             endpoint=self._client.introspection_endpoint)
 
     def client_credentials_grant(self):
-        '''Public method to request access_token using client_credentials flow.
+        """Public method to request access_token using client_credentials flow.
         This is useful for service to service communication where user-agent is
         not available which is required in authorization code flow. Your
-        service can request access_token on startup and can advertise it to
-        other services using a secure channel which can be used to access APIs
-        of your services. How do you share the access_token is outside of the
-        scope of this feature.
+        service can request access_token in order to access APIs of other
+        services.
 
         On API call, token introspection will ensure that only valid token can
         be used to access your APIs.
@@ -269,7 +267,7 @@ class PyoidcFacade:
                                       access_token_required=True)
         >>> auth.init_app(app)
         >>> auth.clients['default'].client_credentials_grant()
-        '''
+        """
         client_credentials_payload = {
             'grant_type': 'client_credentials'
             }

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -252,13 +252,13 @@ class PyoidcFacade:
             endpoint=self._client.introspection_endpoint)
 
     def client_credentials_grant(self):
-        '''Public method to request access_token using client_credentials
-        (previously known as application in OpenApi2.0) flow. This is useful
-        for service to service communication where user-agent is not available
-        which is required in authorization code flow. Your service can request
-        access_token on startup and can advertise it to other services using a
-        secure channel which can be used to access APIs of your services. How
-        do you share the access_token is outside of the scope of this feature.
+        '''Public method to request access_token using client_credentials flow.
+        This is useful for service to service communication where user-agent is
+        not available which is required in authorization code flow. Your
+        service can request access_token on startup and can advertise it to
+        other services using a secure channel which can be used to access APIs
+        of your services. How do you share the access_token is outside of the
+        scope of this feature.
 
         On API call, token introspection will ensure that only valid token can
         be used to access your APIs.
@@ -270,10 +270,10 @@ class PyoidcFacade:
         >>>> auth.init_app(app)
         >>>> auth.clients['default'].client_credentials_grant()
         '''
-        client_credentilas_payload = {
+        client_credentials_payload = {
             'grant_type': 'client_credentials'
         }
-        return self._token_request(request=client_credentilas_payload)
+        return self._token_request(request=client_credentials_payload)
 
     @property
     def session_refresh_interval_seconds(self):

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -262,17 +262,17 @@ class PyoidcFacade:
 
         On API call, token introspection will ensure that only valid token can
         be used to access your APIs.
-        
+
         How To Use
         ----------
         >>> auth = OIDCAuthentication({'default': provider_config},
-                                       access_token_required=True)
+                                      access_token_required=True)
         >>> auth.init_app(app)
         >>> auth.clients['default'].client_credentials_grant()
         '''
         client_credentials_payload = {
             'grant_type': 'client_credentials'
-        }
+            }
         return self._token_request(request=client_credentials_payload)
 
     @property

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -1,6 +1,8 @@
 import time
 
 import base64
+import unittest
+
 import pytest
 import responses
 from oic.oic import AuthorizationResponse, AccessTokenResponse, TokenErrorResponse, OpenIDSchema, \
@@ -15,7 +17,7 @@ from .util import signed_id_token
 REDIRECT_URI = 'https://rp.example.com/redirect_uri'
 
 
-class TestPyoidcFacade(object):
+class TestPyoidcFacade(unittest.TestCase):
     PROVIDER_BASEURL = 'https://op.example.com'
     PROVIDER_METADATA = ProviderMetadata(PROVIDER_BASEURL,
                                          PROVIDER_BASEURL + '/auth',
@@ -230,6 +232,28 @@ class TestPyoidcFacade(object):
                                                     client_metadata=self.CLIENT_METADATA),
                               REDIRECT_URI)
         assert facade.userinfo_request(None) is None
+
+    @responses.activate
+    def test_client_credentials_grant(self):
+        token_endpoint = f'{self.PROVIDER_BASEURL}/token'
+        provider_metadata = self.PROVIDER_METADATA.copy(
+            token_endpoint=token_endpoint)
+        facade = PyoidcFacade(
+            ProviderConfiguration(
+                provider_metadata=provider_metadata,
+                client_metadata=self.CLIENT_METADATA),
+            REDIRECT_URI)
+        client_credentials_grant_response = {
+            'access_token': 'access_token',
+            'expires_in': 60,
+            'not-before-policy': 0,
+            'refresh_expires_in': 0,
+            'scope': 'read write',
+            'token_type': 'Bearer'}
+        responses.add(responses.POST, token_endpoint,
+                      json=client_credentials_grant_response)
+        self.assertEqual(client_credentials_grant_response,
+                         facade.client_credentials_grant().to_dict())
 
 
 class TestClientAuthentication(object):

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -17,7 +17,7 @@ from .util import signed_id_token
 REDIRECT_URI = 'https://rp.example.com/redirect_uri'
 
 
-class TestPyoidcFacade(unittest.TestCase):
+class TestPyoidcFacade:
     PROVIDER_BASEURL = 'https://op.example.com'
     PROVIDER_METADATA = ProviderMetadata(PROVIDER_BASEURL,
                                          PROVIDER_BASEURL + '/auth',
@@ -252,8 +252,7 @@ class TestPyoidcFacade(unittest.TestCase):
             'token_type': 'Bearer'}
         responses.add(responses.POST, token_endpoint,
                       json=client_credentials_grant_response)
-        self.assertEqual(client_credentials_grant_response,
-                         facade.client_credentials_grant().to_dict())
+        assert client_credentials_grant_response == facade.client_credentials_grant().to_dict()
 
 
 class TestClientAuthentication(object):


### PR DESCRIPTION
## Changelogs:

Addresses #75

## Token Introspection

Now the user can send API request directly from curl or from REST API clients. Token introspection method verifies the token before allowing access.

## Token Based Authorization

@auth.token_auth decorator is added to support token based authorization. Token based authorization is backed by token introspection.

## Dual Purpose

@auth.access_control decorator is added that serves dual purpose, that is it can authenticate the user as well as validate the token.

How to use these features is added in its docstring.

## Client Credentials Flow

The service can use Client Credentials Flow to request access token by calling a new public method. With machine-to-machine (M2M) applications, such as CLIs, daemons, or services running on your back-end, the system authenticates and authorizes the app rather than a user. M2M apps use the Client Credentials Flow (defined in OAuth 2.0 RFC 6749, section 4.4), in which they pass along their Client ID and Client Secret to authenticate themselves and get a token. This also eliminates the necessity of having a user-agent in order to authenticate with the Identity Provider. Other services can also use this method to request access token in order to access your APIs.

Client Credentials is backed by token introspection so any usage of access token obtained by client credential flow is verified by token introspection.

How to use this method is added in its docstring.

---

This update doesn't introduce any breaking changes to the codebase of the user. It only adds optional arguments which are default to false should the user choose to update the extension.