### PR TITLE
Support for custom post logout redirect URIs

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -260,7 +260,7 @@ class OIDCAuthentication:
 
             end_session_request = EndSessionRequest(
                 id_token_hint=id_token_jwt,
-                post_logout_redirect_uri=flask.url_for(flask.request.endpoint, _external=True),
+                post_logout_redirect_uri=flask.request.url,
                 state=flask.session['end_session_state'])
 
             logger.debug('send endsession request: %s', end_session_request.to_json())

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -498,16 +498,10 @@ class TestOIDCAuthentication:
         cookie_lifetime = (parsed_expiration - datetime.utcnow()).total_seconds()
         assert cookie_lifetime == pytest.approx(session_lifetime, abs=1)
 
-    @pytest.mark.parametrize('post_logout_redirect_uri', [
-        None,
-        'https://example.com/post_logout'
-    ])
-    def test_logout_redirects_to_provider_if_end_session_endpoint_is_configured(self, post_logout_redirect_uri):
+    def test_logout_redirects_to_provider_if_end_session_endpoint_is_configured(self):
         end_session_endpoint = 'https://provider.example.com/end_session'
-        client_metadata = {}
-        if post_logout_redirect_uri:
-            client_metadata['post_logout_redirect_uris'] = [post_logout_redirect_uri]
-
+        post_logout_redirect_uri = f'http://{self.CLIENT_DOMAIN}/logout'
+        client_metadata = dict(post_logout_redirect_uris=[post_logout_redirect_uri])
         authn = self.init_app(provider_metadata_extras={'end_session_endpoint': end_session_endpoint},
                               client_metadata_extras=client_metadata)
         logout_view_mock = self.get_view_mock()
@@ -531,44 +525,8 @@ class TestOIDCAuthentication:
         assert end_session_redirect.status_code == 303
         assert end_session_redirect.location.startswith(end_session_endpoint)
         assert IdToken().from_jwt(parsed_request['id_token_hint']) == id_token
-
-        expected_post_logout_redirect_uri = post_logout_redirect_uri if post_logout_redirect_uri else 'http://{}/logout'.format(self.CLIENT_DOMAIN)
-        assert parsed_request['post_logout_redirect_uri'] == expected_post_logout_redirect_uri
+        assert parsed_request['post_logout_redirect_uri'] == post_logout_redirect_uri
         assert not logout_view_mock.called
-
-    @patch('flask.helpers.url_for', return_value=f'http://{CLIENT_DOMAIN}/custom-logout')
-    def test_oidc_logout_when_custom_logout_view_function_configured(self, post_logout_custom_redirect_uri):
-
-        end_session_endpoint = 'https://provider.example.com/end_session'
-        custom_logout_view_function = 'test_callback'
-        client_metadata = {}
-        authn = self.init_app(provider_metadata_extras={'end_session_endpoint': end_session_endpoint},
-                              client_metadata_extras=client_metadata)
-        logout_view_mock = self.get_view_mock()
-        id_token = IdToken(**{'sub': 'sub1', 'nonce': 'nonce'})
-
-        # register logout view
-        view_func = authn.oidc_logout(custom_logout_view_function)(logout_view_mock)
-        self.app.add_url_rule('/custom-logout', view_func=logout_view_mock)
-
-        with self.app.test_request_context('/logout'):
-            UserSession(flask.session, self.PROVIDER_NAME).update(access_token='test_access_token',
-                                                                  id_token=id_token.to_dict(),
-                                                                  id_token_jwt=id_token.to_jwt(),
-                                                                  userinfo={'sub': 'user1'})
-            end_session_redirect = view_func()
-
-            # ensure user session has been cleared
-            assert all(k not in flask.session for k in UserSession.KEYS)
-            parsed_request = dict(parse_qsl(urlparse(end_session_redirect.headers['Location']).query))
-            assert parsed_request['state'] == flask.session['end_session_state']
-
-        assert end_session_redirect.status_code == 303
-        assert end_session_redirect.location.startswith(end_session_endpoint)
-        assert IdToken().from_jwt(parsed_request['id_token_hint']) == id_token
-
-        expected_post_custom_logout_redirect_uri = f'http://{self.CLIENT_DOMAIN}/custom-logout'
-        assert parsed_request['post_logout_redirect_uri'] == expected_post_custom_logout_redirect_uri
 
     def test_logout_with_missing_end_session_state_fails_gracefully(self):
         end_session_endpoint = 'https://provider.example.com/end_session'
@@ -1006,16 +964,6 @@ class TestOIDCAuthentication:
                 scopes_required=['read', 'write'])(view_mock)()
             assert view_mock.called
             assert flask._app_ctx_stack.top.current_token_identity == token_introspection_response
-
-    def test_get_url_for_logout_view(self):
-
-        authn = self.init_app()
-        assert authn._get_url_for_logout_view() is None
-        logout_view_mock = self.get_view_mock()
-        authn.oidc_logout(logout_view_mock)
-        self.app.add_url_rule('/logout', view_func=logout_view_mock)
-        with self.app.test_request_context('/'):
-            assert authn._get_url_for_logout_view() == f'http://{self.CLIENT_DOMAIN}/logout'
 
     def test_get_url_for_logout_view_should_raise_build_error_if_mounted_under_custom_endpoint(self):
 

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -266,6 +266,15 @@ class TestPyoidcFacade:
         assert client_credentials_grant_response == facade.client_credentials_grant(
             scope=scope, audience=['client_id1, client_id2']).to_dict()
 
+    def test_property_post_logout_redirect_uris(self):
+        post_logout_redirect_uris = ['https://client.example.com/logout']
+        client_metadata = self.CLIENT_METADATA.copy(
+            post_logout_redirect_uris=post_logout_redirect_uris)
+        facade = PyoidcFacade(ProviderConfiguration(provider_metadata=self.PROVIDER_METADATA,
+                                                    client_metadata=client_metadata),
+                              REDIRECT_URI)
+        assert facade.post_logout_redirect_uris == post_logout_redirect_uris
+
 
 class TestClientAuthentication(object):
     CLIENT_ID = 'client1'


### PR DESCRIPTION
Often times, a web app has 2 or more landing page when the user logs out. Some examples are:

1. If the user clicks on logout, it goes to the sign-in screen.
2. If the user clicks on "Delete My Account", it goes to the "Sorry to let you go", "Give us feedback", "Data Privacy", etc. screens.
3. If the user clicks on "Deactivate My Account", it can land on some informative page that tells the user about how to reactivate the account.

To address these cases, with this enhancement, the user can optionally provide an argument for the name of the `view function` which is resolved by `url_for(view_function_name)` to generate custom post logout redirect URI when the end session request is made.

https://github.com/zamzterz/Flask-pyoidc/blob/40b1163e8055204d27930150ddccaa1da9bd487d/src/flask_pyoidc/flask_pyoidc.py#L263

Currently, `_get_post_logout_redirect_uri` returns whatever post logout redirect URI is present at index zero.

https://github.com/zamzterz/Flask-pyoidc/blob/40b1163e8055204d27930150ddccaa1da9bd487d/src/flask_pyoidc/flask_pyoidc.py#L93

So even if the user has provided list of `post_logout_redirect_uris`  in `ClientMetadata` or in `ClientRegistrationInfo`, other URIs can't be used during the logout session.

`@auth.oidc_logout('name_of_the_view_function)` makes it possible to use other post logout redirect URI as well. This feature is backward compatible so just by decorating the view function with `@auth.oidc_logout` still works as it's.

> Note: If the user is not using Dynamic Client Registeration, all post logout redirect URIs have to be registered manually with the IdP's Valid Redirect URIs.