### PR TITLE
Added scope and extra keyword arguments that can be optionally passed to client crerdentials flow

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -200,9 +200,16 @@ If no error view is specified, a generic error message will be displayed to the 
 The [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4) grant type can be used to obtain an
 access token for your service (outside the context of a user).
 
-Clients can obtain such an access token by using the `client_credentials_grant` method:
+You can obtain such an access token by using the `client_credentials_grant` method:
 
 ```python
 token_response = auth.clients['default'].client_credentials_grant()
 access_token = token_response.get('access_token')
+
+# Optionally, you can specify scopes for the access token.
+auth.clients['default'].client_credentials_grant(
+    scope=['read', 'write'])
+# You can also specify extra keyword arguments to client credentials flow.
+auth.clients['default'].client_credentials_grant(
+    scope=['read', 'write'], audience=['client_id1', 'client_id2'])
 ```

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -277,7 +277,7 @@ class PyoidcFacade:
             auth.init_app(app)
             auth.clients['default'].client_credentials_grant()
 
-        Optionally, you can also specify scope for the access token.
+        Optionally, you can specify scopes for the access token.
 
         ::
 

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -251,7 +251,7 @@ class PyoidcFacade:
             request_args=token_introspection_request,
             endpoint=self._client.introspection_endpoint)
 
-    def client_credentials_grant(self):
+    def client_credentials_grant(self, scope: list = None, **kwargs):
         """Public method to request access_token using client_credentials flow.
         This is useful for service to service communication where user-agent is
         not available which is required in authorization code flow. Your
@@ -261,6 +261,13 @@ class PyoidcFacade:
         On API call, token introspection will ensure that only valid token can
         be used to access your APIs.
 
+        Parameters
+        ----------
+        scope: list, optional
+            List of scopes to be requested.
+        **kwargs : dict, optional
+            Extra arguments to client credentials flow.
+
         Examples
         --------
         ::
@@ -269,10 +276,24 @@ class PyoidcFacade:
                                       access_token_required=True)
             auth.init_app(app)
             auth.clients['default'].client_credentials_grant()
+
+        Optionally, you can also specify scope for the access token.
+
+        ::
+
+            auth.clients['default'].client_credentials_grant(
+                scope=['read', 'write'])
+
+        You can also specify extra keyword arguments to client credentials flow.
+
+        ::
+
+            auth.clients['default'].client_credentials_grant(
+                scope=['read', 'write'], audience=['client_id1', 'client_id2'])
         """
-        client_credentials_payload = {
-            'grant_type': 'client_credentials'
-        }
+        client_credentials_payload = dict(grant_type='client_credentials', **kwargs)
+        if scope:
+            client_credentials_payload['scope'] = ' '.join(scope)
         return self._token_request(request=client_credentials_payload)
 
     @property

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -252,7 +252,8 @@ class TestPyoidcFacade:
             'token_type': 'Bearer'}
         responses.add(responses.POST, token_endpoint,
                       json=client_credentials_grant_response)
-        assert client_credentials_grant_response == facade.client_credentials_grant().to_dict()
+        assert client_credentials_grant_response == facade.client_credentials_grant(
+            scope=['read', 'write'], audience=['client_id1, client_id2']).to_dict()
 
 
 class TestClientAuthentication(object):


### PR DESCRIPTION
To comply with 4.4.2.  Access Token Request of Client Credentials Grant in  RFC 6749.