### PR TITLE
Delegated all requests to pyoidc library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     author_email='samuel.gulliksson@gmail.com',
     description='Flask extension for OpenID Connect authentication.',
     install_requires=[
-        'oic>=1.2.1',
+        'oic>=1.4.0',
         'Flask',
         'requests',
         'importlib_resources'

--- a/src/flask_pyoidc/auth_response_handler.py
+++ b/src/flask_pyoidc/auth_response_handler.py
@@ -71,7 +71,8 @@ class AuthResponseHandler:
         refresh_token = None  # but never refresh token
 
         if 'code' in auth_response:
-            token_resp = self._client.exchange_authorization_code(auth_response['code'])
+            token_resp = self._client.exchange_authorization_code(auth_response['code'],
+                                                                  auth_response['state'])
             if token_resp:
                 if 'error' in token_resp:
                     raise AuthResponseErrorResponseError(token_resp.to_dict())

--- a/src/flask_pyoidc/message_factory.py
+++ b/src/flask_pyoidc/message_factory.py
@@ -1,0 +1,6 @@
+from oic.oauth2.message import AccessTokenResponse, CCAccessTokenRequest, MessageTuple, OauthMessageFactory
+
+
+class CCMessageFactory(OauthMessageFactory):
+    """Client Credential Request Factory."""
+    token_endpoint = MessageTuple(CCAccessTokenRequest, AccessTokenResponse)

--- a/src/flask_pyoidc/provider_configuration.py
+++ b/src/flask_pyoidc/provider_configuration.py
@@ -200,8 +200,8 @@ class ProviderConfiguration:
             registration_response = client.register(
                 url=self._provider_metadata['registration_endpoint'],
                 **registration_request)
+            logger.info('Received registration response.')
             self._client_metadata = ClientMetadata(
                 **registration_response.to_dict())
-            logger.debug('Received registration response: client_id=' + self._client_metadata['client_id'])
 
         return self._client_metadata

--- a/src/flask_pyoidc/provider_configuration.py
+++ b/src/flask_pyoidc/provider_configuration.py
@@ -171,8 +171,8 @@ class ProviderConfiguration:
         self.auth_request_params = auth_request_params or {}
         self.session_refresh_interval_seconds = session_refresh_interval_seconds
         # For session persistence
-        self.requests_session = ClientSettings(timeout=self.DEFAULT_REQUEST_TIMEOUT,
-                                               requests_session=requests_session or requests.Session())
+        self.client_settings = ClientSettings(timeout=self.DEFAULT_REQUEST_TIMEOUT,
+                                              requests_session=requests_session or requests.Session())
 
     def ensure_provider_metadata(self, client: Client):
         if not self._provider_metadata:

--- a/src/flask_pyoidc/provider_configuration.py
+++ b/src/flask_pyoidc/provider_configuration.py
@@ -1,8 +1,9 @@
 import collections.abc
 import logging
 
-from oic.oic import Client
 import requests
+from oic.oic import Client
+from oic.utils.settings import ClientSettings
 
 logger = logging.getLogger(__name__)
 
@@ -169,17 +170,16 @@ class ProviderConfiguration:
         self.userinfo_endpoint_method = userinfo_http_method
         self.auth_request_params = auth_request_params or {}
         self.session_refresh_interval_seconds = session_refresh_interval_seconds
+        # For session persistence
+        self.requests_session = ClientSettings(timeout=self.DEFAULT_REQUEST_TIMEOUT,
+                                               requests_session=requests_session or requests.Session())
 
-        self.requests_session = requests_session or requests.Session()
-
-    def ensure_provider_metadata(self):
+    def ensure_provider_metadata(self, client: Client):
         if not self._provider_metadata:
-            resp = self.requests_session \
-                .get(self._issuer + '/.well-known/openid-configuration',
-                     timeout=self.DEFAULT_REQUEST_TIMEOUT)
-            logger.debug('Received discovery response: ' + resp.text)
+            resp = client.provider_config(self._issuer)
+            logger.debug(f'Received discovery response: {resp.to_dict()}')
 
-            self._provider_metadata = ProviderMetadata(**resp.json())
+            self._provider_metadata = ProviderMetadata(**resp.to_dict())
 
         return self._provider_metadata
 

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -27,16 +27,16 @@ class PyoidcFacade:
         """
         self._provider_configuration = provider_configuration
         self._client = Client(client_authn_method=CLIENT_AUTHN_METHOD,
-                              settings=provider_configuration.requests_session)
+                              settings=provider_configuration.client_settings)
         # Token Introspection is implemented under extension sub-package of
         # the client in pyoidc.
         self._client_extension = ClientExtension(client_authn_method=CLIENT_AUTHN_METHOD,
-                                                 settings=provider_configuration.requests_session)
+                                                 settings=provider_configuration.client_settings)
         # Client Credentials Flow is implemented under oauth2 sub-package of
         # the client in pyoidc.
         self._oauth2_client = Oauth2Client(client_authn_method=CLIENT_AUTHN_METHOD,
                                            message_factory=CCMessageFactory,
-                                           settings=self._provider_configuration.requests_session)
+                                           settings=self._provider_configuration.client_settings)
 
         provider_metadata = provider_configuration.ensure_provider_metadata(self._client)
         self._client.handle_provider_config(ProviderConfigurationResponse(**provider_metadata.to_dict()),

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -253,12 +253,8 @@ class PyoidcFacade:
             'token_type_hint': 'access_token'
         }
         logger.info('making token introspection request')
-        token_introspection_request = self._client_extension.construct_TokenIntrospectionRequest(
-            request_args=request_args
-        )
         token_introspection_response = self._client_extension.do_token_introspection(
-            request_args=token_introspection_request,
-            endpoint=self._client.introspection_endpoint)
+            request_args=request_args, endpoint=self._client.introspection_endpoint)
 
         return token_introspection_response
 

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -149,7 +149,7 @@ class PyoidcFacade:
                                                               authn_method=client_auth_method,
                                                               endpoint=self._client.token_endpoint
                                                               )
-        logger.debug(f'received token response: {token_response}')
+        logger.info('Received token response.')
 
         return token_response
 

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -165,9 +165,6 @@ class PyoidcFacade:
                                                               endpoint=self._client.token_endpoint
                                                               )
         logger.debug(f'received token response: {token_response}')
-        # Store token response in token_class instance. This is required when
-        # making refresh access token request.
-        self._client.token_class = Token(resp=token_response)
 
         return token_response
 
@@ -210,7 +207,7 @@ class PyoidcFacade:
                                                                     'client_secret_basic')
         return self._client.do_access_token_refresh(request_args=request_args,
                                                     authn_method=client_auth_method,
-                                                    token=self._client.token_class,
+                                                    token=Token(resp={'refresh_token': refresh_token}),
                                                     endpoint=self._client.token_endpoint
                                                     )
 

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -1,13 +1,16 @@
 import base64
-import json
 import logging
 
 from oic.extension.client import Client as ClientExtension
 from oic.extension.message import TokenIntrospectionResponse
-from oic.oic import Client, RegistrationResponse, AuthorizationResponse, \
-    AccessTokenResponse, TokenErrorResponse, AuthorizationErrorResponse, OpenIDSchema
-from oic.oic.message import ProviderConfigurationResponse
+from oic.oauth2 import Client as Oauth2Client
+from oic.oauth2.grant import Token
+from oic.oauth2.message import AccessTokenResponse
+from oic.oic import Client
+from oic.oic.message import AuthorizationResponse, ProviderConfigurationResponse, RegistrationResponse
 from oic.utils.authn.client import CLIENT_AUTHN_METHOD
+
+from .message_factory import CCMessageFactory
 
 logger = logging.getLogger(__name__)
 
@@ -52,9 +55,7 @@ class PyoidcFacade:
         """
         self._provider_configuration = provider_configuration
         self._client = Client(client_authn_method=CLIENT_AUTHN_METHOD)
-        # Token Introspection is implemented in extension sub-package of the
-        # client in pyoidc
-        self._client_extension = ClientExtension(client_authn_method=CLIENT_AUTHN_METHOD)
+        self._token = None
 
         provider_metadata = provider_configuration.ensure_provider_metadata()
         self._client.handle_provider_config(ProviderConfigurationResponse(**provider_metadata.to_dict()),
@@ -104,7 +105,7 @@ class PyoidcFacade:
     def login_url(self, auth_request):
         """
         Args:
-            auth_request (AuthorizationRequest): authenticatio request
+            auth_request (AuthorizationRequest): authentication request
         Returns:
             str: Authentication request as a URL to redirect the user to the provider.
         """
@@ -112,34 +113,43 @@ class PyoidcFacade:
 
     def parse_authentication_response(self, response_params):
         """
-        Args:
-            response_params (Mapping[str, str]): authentication response parameters
-        Returns:
-            Union[AuthorizationResponse, AuthorizationErrorResponse]: The parsed authorization response
+        Parameters
+        ----------
+        response_params: Mapping[str, str]
+            authentication response parameters.
+
+        Returns
+        -------
+        Union[AuthorizationResponse, AuthorizationErrorResponse]
+            The parsed authorization response.
         """
-        auth_resp = self._parse_response(response_params, AuthorizationResponse, AuthorizationErrorResponse)
+        auth_resp = self._client.parse_response(AuthorizationResponse, info=response_params, sformat='dict')
         if 'id_token' in response_params:
             auth_resp['id_token_jwt'] = response_params['id_token']
         return auth_resp
 
-    def exchange_authorization_code(self, authorization_code):
-        """
-        Requests tokens from an authorization code.
+    def exchange_authorization_code(self, authorization_code: str, state: str):
+        """Requests tokens from an authorization code.
 
-        Args:
-            authorization_code (str): authorization code issued to client after user authorization
+        Parameters
+        ----------
+        authorization_code: str
+            authorization code issued to client after user authorization
+        state: str
+            state is used to keep track of responses to outstanding requests.
 
-        Returns:
-            Union[AccessTokenResponse, TokenErrorResponse, None]: The parsed token response, or None if no token
-            request was performed.
+        Returns
+        -------
+        Union[AccessTokenResponse, TokenErrorResponse, None]
+            The parsed token response, or None if no token request was performed.
         """
-        request = {
+        request_args = {
             'grant_type': 'authorization_code',
             'code': authorization_code,
             'redirect_uri': self._redirect_uri
         }
 
-        return self._token_request(request)
+        return self._token_request(request_args, state)
 
     def verify_id_token(self, id_token, auth_request):
         """
@@ -156,79 +166,94 @@ class PyoidcFacade:
         """
         self._client.verify_id_token(id_token, auth_request)
 
-    def refresh_token(self, refresh_token):
-        """
-        Requests new tokens using a refresh token.
+    def refresh_token(self, refresh_token: str):
+        """Requests new tokens using a refresh token.
 
-        Args:
-            refresh_token (str): refresh token issued to client after user authorization
+        Parameters
+        ----------
+        refresh_token: str
+            refresh token issued to client after user authorization.
 
-        Returns:
-            Union[AccessTokenResponse, TokenErrorResponse, None]: The parsed token response, or None if no token
-            request was performed.
+        Returns
+        -------
+        Union[AccessTokenResponse, TokenErrorResponse, None]
+            The parsed token response, or None if no token request was performed.
         """
-        request = {
+        request_args = {
             'grant_type': 'refresh_token',
             'refresh_token': refresh_token,
+            'client_id': self._client.client_id,
+            'client_secret': self._client.client_secret,
             'redirect_uri': self._redirect_uri
         }
+        client_auth_method = self._client.registration_response.get('token_endpoint_auth_method',
+                                                                    'client_secret_basic')
+        return self._client.do_access_token_refresh(request_args=request_args,
+                                                    authn_method=client_auth_method,
+                                                    token=self._token,
+                                                    endpoint=self._client.token_endpoint
+                                                    )
 
-        return self._token_request(request)
+    def _token_request(self, request_args: dict, state: str):
+        """Makes a token request.  If the 'token_endpoint' is not configured
+        in the provider metadata, no request will be made.
 
-    def _token_request(self, request):
+        Parameters
+        ----------
+        request_args: dict
+            Token request parameters.
+        state: str
+            state is used to keep track of responses to outstanding requests.
+
+        Returns
+        -------
+        token_response: Union[AccessTokenResponse, TokenErrorResponse, None]
+            The parsed token response, or None if no token request was performed.
         """
-        Makes a token request.  If the 'token_endpoint' is not configured in the provider metadata, no request will
-        be made.
-
-        Args:
-            request (Mapping[str, str]): token request parameters
-
-        Returns:
-            Union[AccessTokenResponse, TokenErrorResponse, None]: The parsed token response, or None if no token
-            request was performed.
-        """
-
         if not self._client.token_endpoint:
             return None
 
-        logger.debug('making token request: %s', request)
-        client_auth_method = self._client.registration_response.get('token_endpoint_auth_method', 'client_secret_basic')
+        logger.debug('making token request: %s', request_args)
+        client_auth_method = self._client.registration_response.get('token_endpoint_auth_method',
+                                                                    'client_secret_basic')
         auth_header = _ClientAuthentication(self._client.client_id, self._client.client_secret)(client_auth_method,
-                                                                                                request)
-        resp = self._provider_configuration.requests_session \
-            .post(self._client.token_endpoint,
-                  data=request,
-                  headers=auth_header) \
-            .json()
-        logger.debug('received token response: %s', json.dumps(resp))
+                                                                                                request_args)
+        token_response = self._client.do_access_token_request(state=state,
+                                                              request_args=request_args,
+                                                              authn_method=client_auth_method,
+                                                              headers=auth_header,
+                                                              endpoint=self._client.token_endpoint
+                                                              )
+        logger.debug(f'received token response: {token_response}')
+        # Store token response in Token class instance. This is required when
+        # making refresh access token request.
+        self._token = Token(resp=token_response)
 
-        token_resp = self._parse_response(resp, AccessTokenResponse, TokenErrorResponse)
-        if 'id_token' in resp:
-            token_resp['id_token_jwt'] = resp['id_token']
+        return token_response
 
-        return token_resp
+    def userinfo_request(self, access_token: str):
+        """Retrieves ID token.
 
-    def userinfo_request(self, access_token):
-        """
-        Args:
-            access_token (str): Bearer access token to use when fetching userinfo
+        Parameters
+        ----------
+        access_token: str
+            Bearer access token to use when fetching userinfo.
 
-        Returns:
-            oic.oic.message.OpenIDSchema: UserInfo Response
+        Returns
+        -------
+        Union[OpenIDSchema, UserInfoErrorResponse, ErrorResponse, None]
         """
         http_method = self._provider_configuration.userinfo_endpoint_method
         if not access_token or http_method is None or not self._client.userinfo_endpoint:
             return None
 
         logger.debug('making userinfo request')
-        userinfo_response = self._provider_configuration.requests_session \
-            .request(http_method, self._client.userinfo_endpoint, headers={'Authorization': f'Bearer {access_token}'}) \
-            .json()
+        userinfo_response = self._client.do_user_info_request(method=http_method, token=access_token)
         logger.debug('received userinfo response: %s', userinfo_response)
 
-        return OpenIDSchema(**userinfo_response)
+        return userinfo_response
 
-    def _token_introspection_request(self, access_token: str):
+    def _token_introspection_request(self, access_token: str) -> TokenIntrospectionResponse:
         """Make token introspection request.
 
         Parameters
@@ -238,23 +263,29 @@ class PyoidcFacade:
 
         Returns
         -------
-        oic.extension.message.TokenIntrospectionResponse
+        TokenIntrospectionResponse
             Response object contains result of the token introspection.
         """
-        request = {
+        request_args = {
             'token': access_token,
+            'client_id': self._client.client_id,
+            'client_secret': self._client.client_secret,
             'token_type_hint': 'access_token'
         }
-        auth_header = _ClientAuthentication(self._client.client_id, self._client.client_secret)('client_secret_basic',
-                                                                                                request)
         logger.info('making token introspection request')
-        response = self._provider_configuration.requests_session \
-            .post(self._client.introspection_endpoint, data=request, headers=auth_header) \
-            .json()
+        # Token Introspection is implemented under extension sub-package of
+        # the client in pyoidc.
+        _client_extension = ClientExtension(client_authn_method=CLIENT_AUTHN_METHOD)
+        token_introspection_request = _client_extension.construct_TokenIntrospectionRequest(
+            request_args=request_args
+        )
+        token_introspection_response = _client_extension.do_token_introspection(
+            request_args=token_introspection_request,
+            endpoint=self._client.introspection_endpoint)
 
-        return TokenIntrospectionResponse(**response)
+        return token_introspection_response
 
-    def client_credentials_grant(self, scope: list = None, **kwargs):
+    def client_credentials_grant(self, scope: list = None, **kwargs) -> AccessTokenResponse:
         """Public method to request access_token using client_credentials flow.
         This is useful for service to service communication where user-agent is
         not available which is required in authorization code flow. Your
@@ -270,6 +301,10 @@ class PyoidcFacade:
             List of scopes to be requested.
         **kwargs : dict, optional
             Extra arguments to client credentials flow.
+
+        Returns
+        -------
+        AccessTokenResponse
 
         Examples
         --------
@@ -294,13 +329,21 @@ class PyoidcFacade:
             auth.clients['default'].client_credentials_grant(
                 scope=['read', 'write'], audience=['client_id1', 'client_id2'])
         """
-        request = {
+        request_args = {
             'grant_type': 'client_credentials',
+            'client_id': self._client.client_id,
+            'client_secret': self._client.client_secret,
             **kwargs
         }
         if scope:
-            request['scope'] = ' '.join(scope)
-        return self._token_request(request)
+            request_args['scope'] = ' '.join(scope)
+        # Client Credentials Flow is implemented under oauth2 sub-package of
+        # the client in pyoidc.
+        _oauth2_client = Oauth2Client(client_authn_method=CLIENT_AUTHN_METHOD,
+                                      message_factory=CCMessageFactory)
+        access_token = _oauth2_client.do_access_token_request(request_args=request_args,
+                                                              endpoint=self._client.token_endpoint)
+        return access_token
 
     @property
     def session_refresh_interval_seconds(self):
@@ -314,11 +357,3 @@ class PyoidcFacade:
     @property
     def post_logout_redirect_uris(self):
         return self._client.registration_response.get('post_logout_redirect_uris')
-
-    def _parse_response(self, response_params, success_response_cls, error_response_cls):
-        if 'error' in response_params:
-            response = error_response_cls(**response_params)
-        else:
-            response = success_response_cls(**response_params)
-            response.verify(keyjar=self._client.keyjar)
-        return response

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -10,8 +10,7 @@ from flask import Flask
 from flask_pyoidc.redirect_uri_config import RedirectUriConfig
 from http.cookies import SimpleCookie
 from jwkest import jws
-from oic.oauth2.grant import Token
-from oic.oic import AuthorizationResponse
+from oic.oic import AuthorizationResponse, Token
 from oic.oic.message import IdToken
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qsl, urlparse, urlencode
@@ -735,7 +734,7 @@ class TestOIDCAuthentication:
     def test_should_refresh_expired_access_token(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._token = Token()
+        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -765,7 +764,7 @@ class TestOIDCAuthentication:
     def test_should_refresh_still_valid_access_token_if_forced(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._token = Token()
+        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -803,7 +802,7 @@ class TestOIDCAuthentication:
     def test_should_return_None_if_token_refresh_request_fails(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._token = Token()
+        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'error': 'invalid_grant',

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -10,6 +10,7 @@ from flask import Flask
 from flask_pyoidc.redirect_uri_config import RedirectUriConfig
 from http.cookies import SimpleCookie
 from jwkest import jws
+from oic.oauth2.grant import Token
 from oic.oic import AuthorizationResponse
 from oic.oic.message import IdToken
 from unittest.mock import MagicMock, patch
@@ -17,8 +18,8 @@ from urllib.parse import parse_qsl, urlparse, urlencode
 from werkzeug.exceptions import Forbidden, Unauthorized
 
 from flask_pyoidc import OIDCAuthentication
-from flask_pyoidc.provider_configuration import ProviderConfiguration, ProviderMetadata, ClientMetadata, \
-    ClientRegistrationInfo
+from flask_pyoidc.provider_configuration import (ProviderConfiguration, ProviderMetadata, ClientMetadata,
+                                                 ClientRegistrationInfo)
 from flask_pyoidc.user_session import UserSession
 from werkzeug.routing import BuildError
 
@@ -734,6 +735,7 @@ class TestOIDCAuthentication:
     def test_should_refresh_expired_access_token(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
+        authn.clients['test_provider']._token = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -763,6 +765,7 @@ class TestOIDCAuthentication:
     def test_should_refresh_still_valid_access_token_if_forced(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
+        authn.clients['test_provider']._token = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -800,6 +803,7 @@ class TestOIDCAuthentication:
     def test_should_return_None_if_token_refresh_request_fails(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
+        authn.clients['test_provider']._token = Token()
 
         token_response = {
             'error': 'invalid_grant',

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -10,7 +10,7 @@ from flask import Flask
 from flask_pyoidc.redirect_uri_config import RedirectUriConfig
 from http.cookies import SimpleCookie
 from jwkest import jws
-from oic.oic import AuthorizationResponse, Token
+from oic.oic import AuthorizationResponse
 from oic.oic.message import IdToken
 from unittest.mock import MagicMock, patch
 from urllib.parse import parse_qsl, urlparse, urlencode
@@ -734,7 +734,6 @@ class TestOIDCAuthentication:
     def test_should_refresh_expired_access_token(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -764,7 +763,6 @@ class TestOIDCAuthentication:
     def test_should_refresh_still_valid_access_token_if_forced(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'access_token': 'new-access-token',
@@ -802,7 +800,6 @@ class TestOIDCAuthentication:
     def test_should_return_None_if_token_refresh_request_fails(self):
         token_endpoint = self.PROVIDER_BASEURL + '/token'
         authn = self.init_app(provider_metadata_extras={'token_endpoint': token_endpoint})
-        authn.clients['test_provider']._client.token_class = Token()
 
         token_response = {
             'error': 'invalid_grant',

--- a/tests/test_provider_configuration.py
+++ b/tests/test_provider_configuration.py
@@ -45,7 +45,7 @@ class TestProviderConfiguration:
 
         provider_config = ProviderConfiguration(issuer=self.PROVIDER_BASEURL,
                                                 client_registration_info=ClientRegistrationInfo())
-        provider_config.ensure_provider_metadata()
+        provider_config.ensure_provider_metadata(Client(CLIENT_AUTHN_METHOD))
         assert provider_config._provider_metadata['issuer'] == self.PROVIDER_BASEURL
         assert provider_config._provider_metadata['authorization_endpoint'] == self.PROVIDER_BASEURL + '/auth'
         assert provider_config._provider_metadata['jwks_uri'] == self.PROVIDER_BASEURL + '/jwks'
@@ -55,7 +55,7 @@ class TestProviderConfiguration:
         provider_config = ProviderConfiguration(provider_metadata=provider_metadata,
                                                 client_registration_info=ClientRegistrationInfo())
 
-        provider_config.ensure_provider_metadata()
+        provider_config.ensure_provider_metadata(Client(CLIENT_AUTHN_METHOD))
         assert provider_config._provider_metadata == provider_metadata
 
     @responses.activate

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -4,7 +4,7 @@ import time
 import pytest
 import responses
 from oic.oic import (AccessTokenResponse, AuthorizationErrorResponse, AuthorizationResponse, Grant, OpenIDSchema,
-                     Token, TokenErrorResponse)
+                     TokenErrorResponse)
 from urllib.parse import parse_qsl
 
 from flask_pyoidc.provider_configuration import ProviderConfiguration, ClientMetadata, ProviderMetadata, \
@@ -179,7 +179,6 @@ class TestPyoidcFacade:
         grant = Grant(resp=token_response)
         grant.grant_expiration_time = now + grant.exp_in
         facade._client.grant = {'test-state': grant}
-        facade._client.token_class = Token(resp=token_response)
 
         responses.add(responses.GET,
                       self.PROVIDER_METADATA['jwks_uri'],

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -9,7 +9,7 @@ from urllib.parse import parse_qsl
 
 from flask_pyoidc.provider_configuration import ProviderConfiguration, ClientMetadata, ProviderMetadata, \
     ClientRegistrationInfo
-from flask_pyoidc.pyoidc_facade import PyoidcFacade, _ClientAuthentication
+from flask_pyoidc.pyoidc_facade import PyoidcFacade
 from .util import signed_id_token
 
 REDIRECT_URI = 'https://rp.example.com/redirect_uri'
@@ -288,32 +288,3 @@ class TestPyoidcFacade:
                                                     client_metadata=client_metadata),
                               REDIRECT_URI)
         assert facade.post_logout_redirect_uris == post_logout_redirect_uris
-
-
-class TestClientAuthentication(object):
-    CLIENT_ID = 'client1'
-    CLIENT_SECRET = 'secret1'
-
-    @property
-    def basic_auth(self):
-        credentials = '{}:{}'.format(self.CLIENT_ID, self.CLIENT_SECRET)
-        return 'Basic {}'.format(base64.urlsafe_b64encode(credentials.encode('utf-8')).decode('utf-8'))
-
-    @pytest.fixture(autouse=True)
-    def setup(self):
-        self.client_auth = _ClientAuthentication(self.CLIENT_ID, self.CLIENT_SECRET)
-
-    def test_client_secret_basic(self):
-        request = {}
-        headers = self.client_auth('client_secret_basic', request)
-        assert headers == {'Authorization': self.basic_auth}
-        assert request == {}
-
-    def test_client_secret_post(self):
-        request = {}
-        headers = self.client_auth('client_secret_post', request)
-        assert headers is None
-        assert request == {'client_id': self.CLIENT_ID, 'client_secret': self.CLIENT_SECRET}
-
-    def test_defaults_to_client_secret_basic(self):
-        assert self.client_auth('invalid_client_auth_method', {}) == self.client_auth('client_secret_basic', {})


### PR DESCRIPTION
All requests for IdP are now entrusted to base library.

# Changelogs

## Delegations
1. `flask_pyoidc.pyoidc_facade.PyoidcFacade.parse_authentication_response` -> `oic.oic.Client.parse_response`
2. `flask_pyoidc.pyoidc_facade.PyoidcFacade.refresh_token` -> `oic.oic.Client.do_access_token_refresh`
3. `flask_pyoidc.pyoidc_facade.PyoidcFacade._token_request` -> `oic.oic.Client.do_access_token_request`
4. `flask_pyoidc.pyoidc_facade.PyoidcFacade.userinfo_request` ->  `oic.oic.Client.do_user_info_request`
5. `flask_pyoidc.pyoidc_facade.PyoidcFacade._token_introspection_request` -> `oic.oic.ClientExtension.do_token_introspection`
6. `flask_pyoidc.pyoidc_facade.PyoidcFacade.client_credentials_grant` -> `oic.oauth2.Client.do_access_token_request`
7. `flask_pyoidc.pyoidc_facade.provider_configuration` -> `oic.oic.Client.provider_config`

## Additions
1. Added message_factory module for Client Credentials Message Factory.
2. Added `oic.utils.settings.ClientSettings` for `requests.Session` persistence. (Depends on OpenIDC/pyoidc#806)

## Tests

Their test cases are modified with respect to https://github.com/OpenIDC/pyoidc/pull/805 which adds support for including `id_token_jwt` in token response.

---

Drafting this PR until the latest version of pyoidc brings `id_token_jwt` support.