### PR TITLE
[RFC-7009] Token Revocation

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -213,3 +213,13 @@ auth.clients['default'].client_credentials_grant(
 auth.clients['default'].client_credentials_grant(
     scope=['read', 'write'], audience=['client_id1', 'client_id2'])
 ```
+
+## Token Revocation
+If you would like to disable an access or refresh token, simply send a request to the `/revoke` endpoint.
+
+> Note: Revoking a token that is invalid, expired, or already revoked returns a 200 OK status code to prevent any information leaks.
+
+```python
+auth.clients['default'].revoke_token(token='access_token',
+                                     token_type_hint='access_token')
+```

--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -266,8 +266,7 @@ class PyoidcFacade:
         --------
         ::
 
-            auth = OIDCAuthentication({'default': provider_config},
-                                      access_token_required=True)
+            auth = OIDCAuthentication({'default': provider_config})
             auth.init_app(app)
             auth.clients['default'].client_credentials_grant()
 


### PR DESCRIPTION
1. To revoke access token or refresh token in case of compromise.
~2. To logout the user from all or unused devices.~
3. To revoke access token obtained by client credentials flow.

## How to use?

```python
auth = OIDCAuthentication({'default': provider_config},
                                      access_token_required=True)
auth.init_app(app)
auth.clients['default'].revoke_token(token='access_token',
    token_type_hint='access_token')
```