### PR TITLE
[Bug] Fixed Redirect URI corruption

### DIFF
--- a/src/flask_pyoidc/pyoidc_facade.py
+++ b/src/flask_pyoidc/pyoidc_facade.py
@@ -44,7 +44,7 @@ class PyoidcFacade:
 
         if self._provider_configuration.registered_client_metadata:
             client_metadata = self._provider_configuration.registered_client_metadata.to_dict()
-            client_metadata.update(redirect_uris=list(redirect_uri))
+            client_metadata.update(redirect_uris=[redirect_uri])
             self._store_registration_info(client_metadata)
 
         self._redirect_uri = redirect_uri

--- a/tests/test_pyoidc_facade.py
+++ b/tests/test_pyoidc_facade.py
@@ -25,7 +25,14 @@ class TestPyoidcFacade:
     def test_registered_client_metadata_is_forwarded_to_pyoidc(self):
         config = ProviderConfiguration(provider_metadata=self.PROVIDER_METADATA, client_metadata=self.CLIENT_METADATA)
         facade = PyoidcFacade(config, REDIRECT_URI)
-        assert facade._client.registration_response
+
+        expected = {
+            'client_id': self.CLIENT_METADATA['client_id'],
+            'client_secret': self.CLIENT_METADATA['client_secret'],
+            'redirect_uris': [REDIRECT_URI],
+            'token_endpoint_auth_method': 'client_secret_basic'
+        }
+        assert facade._client.registration_response.to_dict() == expected
 
     def test_no_registered_client_metadata_is_handled(self):
         config = ProviderConfiguration(provider_metadata=self.PROVIDER_METADATA,


### PR DESCRIPTION
`list(redirect_uri)` was splitting the redirect_uri string into pieces. This bug somehow survived the test cases.

## Bug

```python
redirect_uri = 'https://idp.example.com/callback'
>>> list(redirect_uri)
['h', 't', 't', 'p', 's', ':', '/', '/', 'i', 'd', 'p', '.', 'e', 'x', 'a', 'm', 'p', 'l', 'e', '.', 'c', 'o', 'm', '/', 'c', 'a', 'l', 'l', 'b', 'a', 'c', 'k']
```

## Fix

```python
>>> redirect_uri = ['https://idp.example.com/callback']
['https://idp.example.com/callback']
```