### PR TITLE
replace _app_ctx_stack with g for context storage

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -22,7 +22,7 @@ from urllib.parse import parse_qsl
 
 import flask
 import importlib_resources
-from flask import _app_ctx_stack, current_app
+from flask import current_app, g
 from flask.helpers import url_for
 from oic import rndstr
 from oic.extension.message import TokenIntrospectionResponse
@@ -66,7 +66,7 @@ class OIDCAuthentication:
         # is destroyed between the requests. The value is set by token_auth
         # decorator.
         self.current_token_identity = LocalProxy(lambda: getattr(
-            _app_ctx_stack.top, 'current_token_identity', None))
+            g, 'current_token_identity', None))
         self._redirect_uri_config = redirect_uri_config
 
         if app:
@@ -459,7 +459,7 @@ class OIDCAuthentication:
                     logger.info('Request has valid access token.')
                     # Store token introspection info within the application
                     # context.
-                    _app_ctx_stack.top.current_token_identity = token_introspection_result.to_dict()
+                    g.current_token_identity = token_introspection_result.to_dict()
                     return view_func(*args, **kwargs)
                 # Forbid access if the access token is invalid.
                 flask.abort(403)

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -944,7 +944,7 @@ class TestOIDCAuthentication:
             authn.token_auth(self.PROVIDER_NAME,
                              scopes_required=['read', 'write'])(view_mock)()
             assert view_mock.called
-            assert flask._app_ctx_stack.top.current_token_identity == token_introspection_response
+            assert flask.g.current_token_identity == token_introspection_response
 
     @responses.activate
     def test_token_auth_should_raise_forbidden_if_invalid_token(self):
@@ -1031,7 +1031,7 @@ class TestOIDCAuthentication:
                 self.PROVIDER_NAME,
                 scopes_required=['read', 'write'])(view_mock)()
             assert view_mock.called
-            assert flask._app_ctx_stack.top.current_token_identity == token_introspection_response
+            assert flask.g.current_token_identity == token_introspection_response
 
     def test_get_url_for_logout_view_should_raise_build_error_if_mounted_under_custom_endpoint(self):
         authn = self.init_app()


### PR DESCRIPTION
_app_ctx_stack is deprecated as Flask 2.2.0 and will be removed in Flask 2.4 

see https://github.com/pallets/flask/pull/4682

