### PR TITLE
Fix version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description='Flask extension for OpenID Connect authentication.',
     install_requires=[
         'oic==1.6.0',
-        'pydantic<2.0'
+        'pydantic<2.0',
         'Flask',
         'requests',
         'importlib_resources'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     description='Flask extension for OpenID Connect authentication.',
     install_requires=[
         'oic==1.6.0',
+        'pydantic<2.0'
         'Flask',
         'requests',
         'importlib_resources'


### PR DESCRIPTION
Pyoidc didn't set version constraint for Pydantic and Pydantic version 2 has been released which has breaking changes that are affecting pyoidc. Until they solve the conflict, add pydantic as a dependency and set its version constraint to less than 2.0

https://github.com/CZ-NIC/pyoidc/issues/861