### PR TITLE
Fixed bug when server is behind a proxy

### DIFF
--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -114,7 +114,7 @@ class OIDCAuthentication:
         if not client.is_registered():
             self._register_client(client)
 
-        flask.session['destination'] = flask.request.url
+        flask.session['destination'] = flask.request.full_path
 
         # Use silent authentication for session refresh
         # This will not show login prompt to the user


### PR DESCRIPTION
Avoid using the domain and protocol from the request URL, instead use the path and the URL parameters.