### PR TITLE
Resolve post logout redirect URIs for routes created by blueprints

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -160,9 +160,22 @@ def logout():
     return "You've been successfully logged out!"
 ```
 
-If the logout view is mounted under a custom endpoint (other than the default, which is 
-[the name of the view function](https://flask.palletsprojects.com/en/2.0.x/api/#flask.Flask.route)), or if using Blueprints, you
-must specify the full URL in the Flask-pyoidc configuration using `post_logout_redirect_uris`:
+If you are using Blueprints to create routes, you can provide `logout_view` argument which takes
+[name of the view function](https://flask.palletsprojects.com/en/2.0.x/api/#flask.Flask.route) as parameter. This
+argument is used to resolve URL for `post_logout_redirect_uris`.
+```python
+from flask import Blueprint
+
+blueprint = Blueprint(name='api', import_name=__name__)
+
+@blueprint.route('/logout')
+@auth.oidc_logout(logout_view='api.logout')
+def logout():
+    return "You've been successfully logged out!"
+```
+
+`logout_view` argument is optional to provide in the decorator because you can directly specify
+`post_logout_redirect_uris` as complete URL in the Flask-pyoidc configuration:
 ```python
 ClientMetadata(..., post_logout_redirect_uris=['https://example.com/post_logout']) # if using static client registration
 ClientRegistrationInfo(..., post_logout_redirect_uris=['https://example.com/post_logout']) # if using dynamic client registration 

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -662,6 +662,21 @@ class TestOIDCAuthentication:
 
         self.assert_view_mock(logout_view_mock, result)
 
+    def test_oidc_logout_when_endpoint_name_is_provided(self):
+        authn = self.init_app()
+        # Decorator with an argument.
+        view_func1 = authn.oidc_logout(logout_view='logout1')(self.get_view_mock('logout1'))
+        self.app.add_url_rule('/logout1', 'logout1', view_func=view_func1)
+        view_func2 = authn.oidc_logout(logout_view='test.logout')(self.get_view_mock('logout2'))
+        self.app.add_url_rule('/logout2', 'test.logout', view_func=view_func2)
+        # Decorator without an argument.
+        view_func3 = authn.oidc_logout(self.get_view_mock('logout3'))
+        self.app.add_url_rule('/logout3', 'logout3', view_func=view_func3)
+
+        with self.app.app_context():
+            assert authn._get_urls_for_logout_views() == [f'http://{self.CLIENT_DOMAIN}{endpoint}'
+                                                          for endpoint in ('/logout1', '/logout2', '/logout3')]
+
     def test_authentication_error_response_calls_to_error_view_if_set(self):
         state = 'test_tate'
         error_response = {'error': 'invalid_request', 'error_description': 'test error'}


### PR DESCRIPTION
Addresses:
<!-- gh-issue-number: gh-171-->
* Issue: gh-171
<!-- /gh-issue-number -->

Instead of hardcoding complete post logout redirect URI, oidc_logout should be able to resolve URL from the endpoint name of the view function. We are already doing this for routes that are directly created on app instance. This feature extends the functionality for routes created by Bueprints.