### PR TITLE
Lazy Load Provider Config

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -26,7 +26,14 @@ client_metadata = ClientMetadata(
 provider_config = ProviderConfiguration(issuer='<issuer URL of provider>',
                                         client_metadata=client_metadata)
 
-auth = OIDCAuthentication({'default': provider_config}, app)
+auth = OIDCAuthentication(provider_configurations={'default': provider_config}, app=app)
+```
+
+Flask `app` and provider configurations can be also passed to `init_app`
+to initialize `auth` later.
+```python
+auth = OIDCAuthentication()
+auth.init_app(app=app, provider_configurations={'default': provider_config})
 ```
 
 You can also use a Flask application factory:

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -46,7 +46,7 @@ class OIDCAuthentication:
     OIDCAuthentication object for Flask extension.
     """
 
-    def __init__(self, provider_configurations, app=None,
+    def __init__(self, provider_configurations=None, app=None,
                  redirect_uri_config=None):
         """
         Args:
@@ -72,7 +72,13 @@ class OIDCAuthentication:
         if app:
             self.init_app(app)
 
-    def init_app(self, app):
+    def init_app(self, app, provider_configurations=None):
+        if self._provider_configurations is None and provider_configurations is None:
+            raise ValueError('No provider is configured.')
+
+        if provider_configurations:
+            self._provider_configurations = provider_configurations
+
         if not self._redirect_uri_config:
             self._redirect_uri_config = RedirectUriConfig.from_config(app.config)
 

--- a/src/flask_pyoidc/flask_pyoidc.py
+++ b/src/flask_pyoidc/flask_pyoidc.py
@@ -215,7 +215,7 @@ class OIDCAuthentication:
 
     def oidc_auth(self, provider_name: str):
 
-        if provider_name not in self._provider_configurations:
+        if self._provider_configurations and provider_name not in self._provider_configurations:
             raise ValueError(
                 f"Provider name '{provider_name}' not in configured providers: {self._provider_configurations.keys()}."
             )

--- a/tests/test_flask_pyoidc.py
+++ b/tests/test_flask_pyoidc.py
@@ -75,6 +75,11 @@ class TestOIDCAuthentication:
         assert callback_mock.called
         assert result == self.CALLBACK_RETURN_VALUE
 
+    def test_lazy_init_raises_value_error_if_no_provider_configuration(self):
+        authn = OIDCAuthentication()
+        with pytest.raises(ValueError):
+            authn.init_app(app=self.app)
+
     def test_explicit_redirect_uri_config_should_be_preferred(self):
         redirect_uri_config = RedirectUriConfig('https://example.com/redirect_uri', 'redirect_uri')
         assert OIDCAuthentication({}, self.app, redirect_uri_config)._redirect_uri_config == redirect_uri_config
@@ -156,8 +161,8 @@ class TestOIDCAuthentication:
                                                           post_logout_redirect_uris=post_logout_redirect_uris
                                                       ))
         }
-        authn = OIDCAuthentication(provider_configurations)
-        authn.init_app(self.app)
+        authn = OIDCAuthentication()
+        authn.init_app(self.app, provider_configurations=provider_configurations)
 
         # register logout view to force 'post_logout_redirect_uris' to be included in registration request
         logout_view_mock = self.get_view_mock()


### PR DESCRIPTION
Adds lazy loading of provider config to allow blueprint views to be decorated by auth decorators without initializing auth first. This will provide flexibility to import `auth` instance in blueprint modules before the Flask `app` instance becomes ready.

Fixes:
<!-- gh-issue-number: gh-171-->
* Issue: gh-171
<!-- /gh-issue-number -->